### PR TITLE
Fix getMappedEntrezIDs: use only `all.cpgs` to calculate equiv

### DIFF
--- a/R/getMappedEntrezIDs.R
+++ b/R/getMappedEntrezIDs.R
@@ -112,13 +112,17 @@ getMappedEntrezIDs <- function(sig.cpg, all.cpg=NULL,
         flat.u <- .getFlatAnnotation(array.type,anno)
     }
     
-    if(is.null(all.cpg))
+    if(is.null(all.cpg)) {
         all.cpg <- unique(flat.u$cpg)
-    else{
+    } else {
         all.cpg <- as.character(all.cpg)
         all.cpg <- all.cpg[!is.na(all.cpg)]
         all.cpg <- unique(all.cpg)
     }
+    
+    # remove CpGs from annotation that are not in all.cpg
+    m_all <- match(flat.u$cpg, all.cpg)
+    flat.u = flat.u[!is.na(m_all),]
     
     # map CpG sites to entrez gene id's
     sig.cpg <- unique(sig.cpg)


### PR DESCRIPTION
Hi,

I believe there is a bug in the `getMappedEntrezIDs` function which means that `equiv` is calculated using all CpGs in the array (and not only those contained in `all.cpg`).  This is in contrast to `freq` - which doesn't account for multimapping CpGs but does use only those CpGs defined in `all.cpg`.

As I understand it, `equiv` should always be equal to or less than `freq`.  Without the fix we get this:

```
library(tidyverse)

set.seed(1)

anno = missMethyl:::.getFlatAnnotation("EPIC")

all.cpg = sample(anno$cpg, size = 500000, replace = FALSE)
sig.cpg = sample(all.cpgs, size = 10000, replace = FALSE)

out = missMethyl::getMappedEntrezIDs(sig.cpg, all.cpg)

qplot(out$equiv, out$freq) +
  geom_abline(intercept = 1)
```
![equiv_vs_freq](https://user-images.githubusercontent.com/26086766/93900448-4d25e800-fced-11ea-938e-d5fe50c37174.png)

```
sum(out$equiv > out$freq)
```
gives us 15653 CpGs with higher `equiv` values than `freq`

With the fix (which is only a few lines). we get:

![equiv_vs_freq_fix](https://user-images.githubusercontent.com/26086766/93902117-1f41a300-fcef-11ea-9cb3-1890241d3450.png)

I believe this bug has an impact in your `gsameth` function since you're calculating the bias using all the CpGs in the array and not only those in `all.cpg`.

